### PR TITLE
Fix code scanning alert no. 2: Prototype-polluting assignment

### DIFF
--- a/myenv/lib/python3.12/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
+++ b/myenv/lib/python3.12/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
@@ -12,10 +12,18 @@ const encoder = new TextEncoder();
 self.addEventListener("message", async function (event) {
   if (event.data.close) {
     let connectionID = event.data.close;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error("Invalid connectionID");
+      return;
+    }
     delete connections[connectionID];
     return;
   } else if (event.data.getMore) {
     let connectionID = event.data.getMore;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error("Invalid connectionID");
+      return;
+    }
     let { curOffset, value, reader, intBuffer, byteBuffer } =
       connections[connectionID];
     // if we still have some in buffer, then just send it back straight away


### PR DESCRIPTION
Fixes [https://github.com/alexpolo1/pdftoaudiobook/security/code-scanning/2](https://github.com/alexpolo1/pdftoaudiobook/security/code-scanning/2)

To fix the problem, we need to ensure that the `connectionID` cannot be set to special property names like `__proto__`, `constructor`, or `prototype`. This can be achieved by adding a check before using `connectionID` as a key in the `connections` object. If `connectionID` matches any of these special property names, we should handle it appropriately, such as by ignoring the request or returning an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
