### PR TITLE
Fix code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/myenv/lib/python3.12/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
+++ b/myenv/lib/python3.12/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
@@ -12,10 +12,18 @@ const encoder = new TextEncoder();
 self.addEventListener("message", async function (event) {
   if (event.data.close) {
     let connectionID = event.data.close;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error("Invalid connectionID");
+      return;
+    }
     delete connections[connectionID];
     return;
   } else if (event.data.getMore) {
     let connectionID = event.data.getMore;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error("Invalid connectionID");
+      return;
+    }
     let { curOffset, value, reader, intBuffer, byteBuffer } =
       connections[connectionID];
     // if we still have some in buffer, then just send it back straight away
@@ -63,6 +71,10 @@ self.addEventListener("message", async function (event) {
   } else {
     // start fetch
     let connectionID = nextConnectionID;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error("Invalid connectionID");
+      return;
+    }
     nextConnectionID += 1;
     const intBuffer = new Int32Array(event.data.buffer);
     const byteBuffer = new Uint8Array(event.data.buffer, 8);


### PR DESCRIPTION
Fixes [https://github.com/alexpolo1/pdftoaudiobook/security/code-scanning/1](https://github.com/alexpolo1/pdftoaudiobook/security/code-scanning/1)

To fix the prototype pollution vulnerability, we need to ensure that the `connectionID` cannot be set to a value that would modify `Object.prototype`. This can be achieved by validating the `connectionID` before using it as a key in the `connections` object. Specifically, we should check if `connectionID` is one of the dangerous property names (`__proto__`, `constructor`, `prototype`) and reject it if so.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
